### PR TITLE
use latest release if not provided

### DIFF
--- a/opusfilter/opusfilter.py
+++ b/opusfilter/opusfilter.py
@@ -131,6 +131,12 @@ class OpusFilter:
             logger.info("Output files exists, skipping step")
             return
 
+        try:
+            parameters['release']
+        except KeyError:
+            logger.info("No release version provided, using 'latest'")
+            parameters['release'] = 'latest'
+
         opus_reader = OpusRead(
             directory=parameters['corpus_name'],
             source=parameters['source_language'],


### PR DESCRIPTION
I found it a bit difficult to find out exactly what the latest versions of corpora were on `OPUS`. `OpusTools` uses `latest` as the default version (https://github.com/Helsinki-NLP/OpusTools/blob/master/opustools_pkg/README.md) but this behaviour is not supported in `OpusFilter` and if you do not pass `release:` to the `opus_read` step then there is a `KeyError`.

This small change checks to see if a `release:` was provided and if not, it sets the key's value as `'latest'`. This may be helpful for incremental release changes e.g. `Paracrawl v7.1`. This behaviour is applied in a test file below but is not supported by the main library yet: https://github.com/Helsinki-NLP/OpusFilter/blob/46b3663c049ece62cf319a75e9dd021c5198ccc0/tests/test_opus_filter.py#L24.


