### PR TITLE
Add support to fasttext for language detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ htmlcov
 *.xml
 *.zip
 *.gz
+venv
+.vscode
+scripts

--- a/README.md
+++ b/README.md
@@ -14,11 +14,14 @@ Features:
   aligment, and n-gram language models
 * Extendable with your own filters written in Python
 
+OpusFilter has been presented in [ACL 2020 system demonstrations](https://www.aclweb.org/anthology/2020.acl-demos.20).
+
 ## Table of contents
 
 * [Installing](#installing)
    * [Required libraries](#required-libraries)
    * [Optional libraries and tools](#optional-libraries-and-tools)
+* [Citing](#citing)
 * [Overview](#overview)
    * [Examples](#examples)
 * [Available functions](#available-functions)
@@ -90,6 +93,24 @@ For using word alignment filters, you need to install elfomal
 (https://github.com/robertostling/eflomal) and set environment
 variable `EFLOMAL_PATH` to eflomal's root directory, which contains
 the Python scripts `align.py` and `makepriors.py`.
+
+## Citing
+
+If you use OpusFilter in your research, please cite our [ACL 2020 paper](https://www.aclweb.org/anthology/2020.acl-demos.20):
+
+```
+@inproceedings{aulamo-etal-2020-opusfilter,
+    title = "{O}pus{F}ilter: A Configurable Parallel Corpus Filtering Toolbox",
+    author = {Aulamo, Mikko and Virpioja, Sami and Tiedemann, J{\"o}rg},
+    booktitle = "Proceedings of the 58th Annual Meeting of the Association for Computational Linguistics: System Demonstrations",
+    month = jul,
+    year = "2020",
+    publisher = "Association for Computational Linguistics",
+    url = "https://www.aclweb.org/anthology/2020.acl-demos.20",
+    doi = "10.18653/v1/2020.acl-demos.20",
+    pages = "150--156"
+}
+```
 
 ## Overview
 

--- a/opusfilter/opusfilter.py
+++ b/opusfilter/opusfilter.py
@@ -202,6 +202,7 @@ class OpusFilter:
         else:
             pairs = filter_pipe.filter(pairs_gen)
         limit = parameters.get('limit')
+        last_idx = 0
         with file_open(src_out, 'w') as source_file, \
                 file_open(tgt_out, 'w') as target_file:
             for idx, pair in enumerate(pairs):
@@ -209,10 +210,11 @@ class OpusFilter:
                 target_file.write(pair[1]+'\n')
                 source_file.flush()
                 target_file.flush()
+                last_idx = idx
                 if limit and idx >= limit - 1:
                     break
         if not limit:
-            removed = pairs_gen.n - idx
+            removed = pairs_gen.n - last_idx
             logger.info("Filtered out {} / {} = {:.2f}% lines".format(
                 removed, pairs_gen.n, 100 * removed / pairs_gen.n))
 


### PR DESCRIPTION
Hello everyone, I would like to contribute to your project by adding the support of fasttext for language detection.

Indeed, compares to langid, cld and langdetect, fasttext has 2 big advantages : 
- It's much more accurate (cf [this medium article](https://towardsdatascience.com/benchmarking-language-detection-for-nlp-8250ea8b67c), and I double checked on tatoeba corpus to be sure)
- It's much faster (cf [this same medium article](https://towardsdatascience.com/benchmarking-language-detection-for-nlp-8250ea8b67c)) , by a factor of more than 100. 

The speed gain is huge because the language detection filtering is the biggest bottleneck between all filters you have in OpusFilter.  For instance, for 8 millions of korean_english sentences, the filtering went from many hours to less than 10 minutes on my machine. And the quality is better.

Is there any things I should add to have more chance to have this PR accepted ? Some test ? Some documentation ?

Thanks !
Kirian