### PR TITLE
fix: missing the checker for param

### DIFF
--- a/opusfilter/opusfilter.py
+++ b/opusfilter/opusfilter.py
@@ -413,7 +413,7 @@ class OpusFilter:
 
     def train_alignment(self, parameters, overwrite=False):
         """Train eflomal alignment priors"""
-        self._check_extra_parameters({'src_data', 'tgt_data', 'scores', 'parameters'}, parameters)
+        self._check_extra_parameters({'src_data', 'tgt_data', 'scores', 'parameters', 'output'}, parameters)
         self._check_extra_parameters({'src_tokenizer', 'tgt_tokenizer', 'model'}, parameters.get('parameters'))
         model_out = os.path.join(self.output_dir, parameters['output'])
         if not overwrite and os.path.isfile(model_out):


### PR DESCRIPTION
In command `train_alignment`, missing checker for param `output`. 
```
  - type: train_alignment
    parameters:
      src_data: zh.rules
      tgt_data: en.rules
      scores: align_score.jsonl
      output: align.priors
      parameters:
        model: 3
        src_tokenizer: [jieba, zh]
        tgt_tokenizer: [moses, en]
```
The error will raise
```
Traceback (most recent call last):
  File "/home/hanbing/miniconda3/envs/opus/bin/opusfilter", line 7, in <module>
    exec(compile(f.read(), __file__, 'exec'))
  File "/home/hanbing/projects/OpusFilter/bin/opusfilter", line 27, in <module>
    of.execute_steps(overwrite=args.overwrite, last=args.last)
  File "/home/hanbing/projects/OpusFilter/opusfilter/opusfilter.py", line 121, in execute_steps
    self._run_step(step, num + 1, overwrite)
  File "/home/hanbing/projects/OpusFilter/opusfilter/opusfilter.py", line 186, in _run_step
    self.step_functions[step['type']](parameters, overwrite=overwrite)
  File "/home/hanbing/projects/OpusFilter/opusfilter/opusfilter.py", line 418, in train_alignment
    model_out = os.path.join(self.output_dir, parameters['output'])
KeyError: 'output'
```