### PR TITLE
fix jieba tokenize and detokenize funcs.

### DIFF
--- a/opusfilter/tokenization.py
+++ b/opusfilter/tokenization.py
@@ -1,7 +1,6 @@
 """Tokenization tools"""
 
 import logging
-import re
 
 from . import ConfigurationError
 

--- a/opusfilter/tokenization.py
+++ b/opusfilter/tokenization.py
@@ -1,6 +1,7 @@
 """Tokenization tools"""
 
 import logging
+import re
 
 from . import ConfigurationError
 
@@ -105,7 +106,8 @@ class JiebaTokenizer(DummyTokenizer):
         return ' '.join(self.jieba.cut(string, **self.options))
 
     def detokenize(self, string):
-        return ''.join(string.split())
+        segments = ["".join(item.split(" ")) for item in string.split("   ")]
+        return " ".join(segments)
 
 
 class MeCabTokenizer(DummyTokenizer):

--- a/tests/test_tokenization.py
+++ b/tests/test_tokenization.py
@@ -60,8 +60,8 @@ class TestTokenization(unittest.TestCase):
     @unittest.skipIf('jieba' not in globals(), 'jieba not installed')
     def test_jieba_detok(self):
         tokenize = tokenization.get_tokenize(('jieba', 'zh'))
-        tokens = "同时 ， 祖马 革命 的 一代 似乎 对 领导 打破 种族隔离 制度 15 年 后 的 南非 ， 还 不 适应 。"
-        reference = "同时，祖马革命的一代似乎对领导打破种族隔离制度15年后的南非，还不适应。"
+        tokens = "同时 ， 祖马 革命 的 一代 似乎 对 领导 打破 种族隔离 制度 15 年 后 的 南非 （ South   Africa ) ， 还 不 适应 。"
+        reference = "同时，祖马革命的一代似乎对领导打破种族隔离制度15年后的南非（South Africa)，还不适应。"
         self.assertEqual(tokenize.detokenize(tokens), reference)
 
     @unittest.skipIf('jieba' not in globals(), 'jieba not installed')


### PR DESCRIPTION
Chinese tokenizer jieba tokenize Chinese and export an list object. For example:
```
我是一个中国人，我会说英语Hello world!
```
The tokenize result is as folllow:
```python
import jieba
result = list(jieba.cut("我是一个中国人，我会说英语Hello world!")
```
output
```python
["我是", "一个", "中国人", "，",  "我",  "会", "说", "英语", "Hello",  " ",  "world", "!"]
```
The space between "Hello world" will be treated as a word.
When joined into string, it looks like this
```
我是 一个 中国人 ,  我 会 说 英语 Hello   world !
```
The old detokenize code just split it by space, and join it together. And the origin space between `Hello` and `World` will disappear.
```
我是一个中国人，我会说英语Helloworld!
```
This PR fix this.
