### PR TITLE
feature: add parallel decorator for functions preprocess, score, and filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ sections:
 
 The syntax for the `opusfilter` is
 ```
-opusfilter [--overwrite] [--last LAST] [--single SINGLE] CONFIG
+opusfilter [--overwrite] [--last LAST] [--single SINGLE] [--n_jobs N_JOBS] CONFIG
 ```
 where `CONFIG` is path to the configuration file.
 The script will run the steps one by one and stops when the final step
@@ -219,7 +219,7 @@ options for setting the last step to run (`--last`) and running
 only a single step (`--single`). It the latter, the user has to
 make sure that all input files for the step already exist. The first
 step has number 1, and -1 points to the last step, -2 to the second to
-last, and so on.
+last, and so on. The `--n_jobs` option indicate number of processes to use when running `score`, `filter` and `preprocess` steps. This value will overwrite `default_n_jobs` in `common` section below.
 
 By default, existing output files will be re-used, and the steps
 producing them skipped. The `--overwrite` option will force overwrite
@@ -233,6 +233,7 @@ The valid options for the `common` section includes:
   (with `filterfalse` option) and `score` steps. Increasing the value
   from the default 100000 may speed up things at the cost of increased
   memory use.
+* `default_n_jobs` for parallel run `score`, `filter` and `preprocess` steps. It indicate the number of processes to uese. The default value is 1.
 * `constants` for setting constants; see
   [Variables and constants](#variables-and-constants).
 
@@ -662,12 +663,13 @@ Useful mostly for testing.
 
 #### `preprocess`
 
-Filter parallel data with a combination of filters.
+Preprocess text with a combination of preprocessors.
 
 Parameters:
 
 * `inputs`: input files for segments to preprocess
 * `outputs`: output files for preprocessed segments
+* `n_jobs`: number of sub processes to parallel run jobs. If not set, the default value is `default_n_jobs` in `common` section.
 * `preprocessors`: a list of preprocessors to apply; see below
 
 The preprocessors parameter is a list of dictionaries, each
@@ -730,6 +732,7 @@ Parameters:
 
 * `inputs`: input files for segments to filter
 * `outputs`: output files for filtered sentences
+* `n_jobs`: number of sub processes to parallel run jobs. If not set, the default value is `default_n_jobs` in `common` section.
 * `filters`: a list of filters to apply; see below
 * `filterfalse`: yield segment pairs that do not pass at least one of the filters (optional; default `false`)
 
@@ -759,6 +762,7 @@ Parameters:
 
 * `inputs`: input files for segments to score
 * `output`: output file for the scores
+* `n_jobs`: number of sub processes to parallel run jobs. If not set, the default value is `default_n_jobs` in `common` section.
 * `filters`: a list of filters to apply; see below
 
 The filters are defined in the same manner as in the `filter`

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ sections:
 
 The syntax for the `opusfilter` is
 ```
-opusfilter [--overwrite] [--last LAST] [--single SINGLE] [--n_jobs N_JOBS] CONFIG
+opusfilter [--overwrite] [--last LAST] [--single SINGLE] [--n-jobs N_JOBS] CONFIG
 ```
 where `CONFIG` is path to the configuration file.
 The script will run the steps one by one and stops when the final step
@@ -219,7 +219,9 @@ options for setting the last step to run (`--last`) and running
 only a single step (`--single`). It the latter, the user has to
 make sure that all input files for the step already exist. The first
 step has number 1, and -1 points to the last step, -2 to the second to
-last, and so on. The `--n_jobs` option indicate number of processes to use when running `score`, `filter` and `preprocess` steps. This value will overwrite `default_n_jobs` in `common` section below.
+last, and so on. The `--n-jobs` option indicate number of processes to
+use when running `score`, `filter` and `preprocess` steps. This value will 
+overwrite `default_n_jobs` in the `common` section.
 
 By default, existing output files will be re-used, and the steps
 producing them skipped. The `--overwrite` option will force overwrite
@@ -233,7 +235,8 @@ The valid options for the `common` section includes:
   (with `filterfalse` option) and `score` steps. Increasing the value
   from the default 100000 may speed up things at the cost of increased
   memory use.
-* `default_n_jobs` for parallel run `score`, `filter` and `preprocess` steps. It indicate the number of processes to uese. The default value is 1.
+* `default_n_jobs` for defining the number of parallel processes to use
+  for `score`, `filter`, and `preprocess` steps. The default value is 1.
 * `constants` for setting constants; see
   [Variables and constants](#variables-and-constants).
 

--- a/bin/opusfilter
+++ b/bin/opusfilter
@@ -17,7 +17,7 @@ parser.add_argument('config', metavar='CONFIG', help='YAML configuration file')
 parser.add_argument('--overwrite', '-o', help='overwrite existing output files', action='store_true')
 parser.add_argument('--last', type=int, default=None, help='Last step to run')
 parser.add_argument('--single', type=int, default=None, help='Run only the nth step')
-parser.add_argument('--n_jobs', type=int, default=None,
+parser.add_argument('--n-jobs', type=int, default=None,
     help='Number of parallel jobs when running score, filter and preprocess.')
 
 args = parser.parse_args()

--- a/bin/opusfilter
+++ b/bin/opusfilter
@@ -17,10 +17,14 @@ parser.add_argument('config', metavar='CONFIG', help='YAML configuration file')
 parser.add_argument('--overwrite', '-o', help='overwrite existing output files', action='store_true')
 parser.add_argument('--last', type=int, default=None, help='Last step to run')
 parser.add_argument('--single', type=int, default=None, help='Run only the nth step')
+parser.add_argument('--n_jobs', type=int, default=None,
+    help='Number of parallel jobs when running score, filter and preprocess.')
 
 args = parser.parse_args()
 
 configuration = yaml.load(open(args.config))
+if args.n_jobs is not None:
+    configuration['common']['default_n_jobs'] = args.n_jobs
 
 of = OpusFilter(configuration)
 if args.single is None:

--- a/opusfilter/opusfilter.py
+++ b/opusfilter/opusfilter.py
@@ -107,11 +107,11 @@ class ParallelWrapper:
         for i, lines in enumerate(zip(*infileobjs)):
             if i % chunk_size == 0:
                 intmpfiles = [tempfile.mkstemp(dir=os.path.dirname(infile),
-                              suffix=f"part{str(i // chunk_size)}.{os.path.basename(infile)}")[1] for infile in infiles]
+                              suffix=f".part{str(i // chunk_size)}.{os.path.basename(infile)}")[1] for infile in infiles]
                 in_chunked_files.append(intmpfiles)
                 intmpfiles_objs = [file_open(intmpfile, mode="w") for intmpfile in intmpfiles]
                 outtmpfiles = [tempfile.mktemp(dir=os.path.dirname(outfile),
-                               suffix=f"part{str(i // chunk_size)}.{os.path.basename(outfile)}") for outfile in outfiles]
+                               suffix=f".part{str(i // chunk_size)}.{os.path.basename(outfile)}") for outfile in outfiles]
                 out_chunked_files.append(outtmpfiles)
 
             for line, tmpfile in zip(lines, intmpfiles_objs):

--- a/opusfilter/opusfilter.py
+++ b/opusfilter/opusfilter.py
@@ -5,11 +5,14 @@ import copy
 import functools
 import itertools
 import logging
+import math
+import multiprocessing
 import operator
 import os
 import pickle
 import random
 import tempfile
+from itertools import chain
 
 import json
 import numpy as np
@@ -26,7 +29,7 @@ from . import subwords
 from . import tokenization
 from . import classifier
 from . import segment_hash
-from .util import file_open, file_download, Var, VarStr
+from .util import file_open, file_download, Var, VarStr, count_lines
 
 
 logger = logging.getLogger(__name__)
@@ -71,6 +74,105 @@ def dict_set(key, value, dictionary):
         dictionary = dictionary[first]
 
 
+class ParallelWrapper:
+    """
+    Decorator for parallelizing 'filter_data', 'score_data' and 'preprocess' methods.
+    This decorator will split "inputs" and "outputs" (or "output") into shareds and process them in parallel.
+    Finally, all the intermediate result will be merged into a single file $name. All the intermediate files will be deleted.
+    """
+
+    def __init__(self, extra_parameters):
+        if "inputs" not in extra_parameters:
+            raise ConfigurationError("'inputs' is required in extra_parameters to parallelize.")
+        if "outputs" not in extra_parameters and "output" not in extra_parameters:
+            raise ConfigurationError("'outputs' or 'output' is required in extra_parameters to parallelize.")
+        self.extra_parameters = extra_parameters
+        self.func = None
+
+    def __call__(self, func):
+        self.func = func
+
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            return self.parallelize(*args, **kwargs)
+        return wrapper
+
+    @staticmethod
+    def split(infiles, outfiles, n_jobs):
+        """split files into parts, and write them to temporary files"""
+        chunk_size = int(math.ceil(count_lines(infiles[0]) / n_jobs))
+        in_chunked_files = []
+        out_chunked_files = []
+        infileobjs = [file_open(infile) for infile in infiles]
+        for i, lines in enumerate(zip(*infileobjs)):
+            if i % chunk_size == 0:
+                intmpfiles = [tempfile.mkstemp(dir=os.path.dirname(infile),
+                              suffix=f"part{str(i // chunk_size)}.{os.path.basename(infile)}")[1] for infile in infiles]
+                in_chunked_files.append(intmpfiles)
+                intmpfiles_objs = [file_open(intmpfile, mode="w") for intmpfile in intmpfiles]
+                outtmpfiles = [tempfile.mktemp(dir=os.path.dirname(outfile),
+                               suffix=f"part{str(i // chunk_size)}.{os.path.basename(outfile)}") for outfile in outfiles]
+                out_chunked_files.append(outtmpfiles)
+
+            for line, tmpfile in zip(lines, intmpfiles_objs):
+                tmpfile.write(line)
+        return in_chunked_files, out_chunked_files
+
+    @staticmethod
+    def merge(in_chunked_files, outfiles, out_chunked_files, limit):
+        """merge temporary files into final files and delete temporary files"""
+        for outfile, parts in zip(outfiles, zip(*out_chunked_files)):
+            with file_open(outfile, 'w') as out:
+                finput = chain.from_iterable(file_open(part) for part in parts)
+                for i, line in enumerate(finput):
+                    out.write(line)
+                    if limit and i >= limit - 1:
+                        break
+            for part in parts:
+                os.unlink(part)
+        for parts in in_chunked_files:
+            for part in parts:
+                os.unlink(part)
+
+    def parallelize(self, obj, parameters, overwrite=False):
+        """Wrapper for parallelizing a function"""
+        # check if parameters are valid
+        n_jobs = parameters.pop('n_jobs', obj.default_n_jobs)
+        if n_jobs <= 1:
+            self.func(obj, parameters, overwrite)
+            return
+        # pylint: disable=W0212
+        obj._check_extra_parameters(self.extra_parameters, parameters)
+        infiles = [os.path.join(obj.output_dir, fname) for fname in parameters['inputs']]
+        if "outputs" in parameters:
+            outfiles = [os.path.join(obj.output_dir, fname) for fname in parameters['outputs']]
+        elif "output" in parameters:  # function `score` use `output` instead of `outputs`
+            outfiles = [os.path.join(obj.output_dir, parameters['output'])]
+        if len(outfiles) != len(infiles) and "outputs" in parameters:
+            raise ConfigurationError("Number of input and output files should match in sort")
+        if not overwrite and all(os.path.isfile(outfile) for outfile in outfiles):
+            logger.info("Output files exists, skipping step")
+            return
+        in_chunked_files, out_chunked_files = self.split(infiles, outfiles, n_jobs)
+        # run jobs in parallel
+        sub_processes = []
+        for intmpfiles, outtmpfiles in zip(in_chunked_files, out_chunked_files):
+            parameters_i = copy.deepcopy(parameters)
+            parameters_i["inputs"] = intmpfiles
+            if "outputs" in parameters:
+                parameters_i["outputs"] = [os.path.relpath(path, obj.output_dir) for path in outtmpfiles]
+            elif "output" in parameters:  # function `score` use `output` instead of `outputs`
+                parameters_i["output"] = os.path.relpath(outtmpfiles[0], obj.output_dir)
+            process = multiprocessing.Process(target=self.func, args=(obj, parameters_i, overwrite))
+            process.daemon = True
+            process.start()
+            sub_processes.append(process)
+        for process in sub_processes:
+            process.join()
+        limit = parameters.get('limit', None)
+        self.merge(in_chunked_files, outfiles, out_chunked_files, limit)
+
+
 # pylint: disable=R0904
 class OpusFilter:
     """Apply filters to language data"""
@@ -86,6 +188,7 @@ class OpusFilter:
             os.mkdir(self.output_dir)
         self.constants = configuration.get('common', {}).get('constants', {})
         self.chunksize = configuration.get('common', {}).get('chunksize', 100000)
+        self.default_n_jobs = configuration.get('common', {}).get('default_n_jobs', 1)
         self.step_functions = {
             'opus_read': self.read_from_opus,
             'filter': self.filter_data,
@@ -253,10 +356,10 @@ class OpusFilter:
         for fobj in files:
             fobj.close()
 
+    @ParallelWrapper({'inputs', 'outputs', 'filters', 'filterfalse', 'limit'})
     def filter_data(self, parameters, overwrite=False):
         """Write sentences to file if they pass given filters"""
-        self._check_extra_parameters(
-            {'inputs', 'outputs', 'filters', 'filterfalse', 'limit'}, parameters)
+        # no need to check extra parameters, they are checked in the parallel wrapper
         outfiles = [os.path.join(self.output_dir, fname) for fname in parameters['outputs']]
         infiles = [os.path.join(self.output_dir, fname) for fname in parameters['inputs']]
         if len(outfiles) != len(infiles):
@@ -456,9 +559,10 @@ class OpusFilter:
             for line in fobj:
                 yield json.loads(line)
 
+    @ParallelWrapper({'inputs', 'output', "filters"})
     def score_data(self, parameters, overwrite=False):
         """Score language data based on given filters"""
-        self._check_extra_parameters({'inputs', 'output', 'filters'}, parameters)
+        # no need to check extra parameters, they are checked in the parallel wrapper
         infiles = [os.path.join(self.output_dir, fname) for fname in parameters['inputs']]
         score_out = os.path.join(self.output_dir, parameters['output'])
         if not overwrite and os.path.isfile(score_out):
@@ -850,9 +954,10 @@ class OpusFilter:
                 for part, outf in zip(parts, outfs):
                     outf.write(part.strip() + '\n')
 
+    @ParallelWrapper({'inputs', 'outputs', 'preprocessors'})
     def preprocess(self, parameters, overwrite=False):
         """Run preprocessors on text data"""
-        self._check_extra_parameters({'inputs', 'outputs', 'preprocessors'}, parameters)
+        # no need to check extra parameters, they are checked in the parallel wrapper
         outfiles = [os.path.join(self.output_dir, fname) for fname in parameters['outputs']]
         infiles = [os.path.join(self.output_dir, fname) for fname in parameters['inputs']]
         if len(outfiles) != len(infiles):

--- a/opusfilter/tokenization.py
+++ b/opusfilter/tokenization.py
@@ -15,6 +15,7 @@ except ImportError:
 
 try:
     import jieba
+    jieba.setLogLevel(logging.INFO)
 except ImportError:
     logger.warning("Could not import jieba, Chinese tokenization with jieba not supported")
 

--- a/opusfilter/util.py
+++ b/opusfilter/util.py
@@ -185,3 +185,9 @@ def yaml_dumps(obj):
         yaml.dump(obj, iostream)
         iostream.seek(0)
         return iostream.read()
+
+
+def count_lines(filename):
+    """Count lines in a file"""
+    with file_open(filename) as fobj:
+        return sum(1 for _ in fobj)

--- a/tests/test_opusfilter.py
+++ b/tests/test_opusfilter.py
@@ -1192,8 +1192,7 @@ class TestParallel(unittest.TestCase):
                               {'CharacterScoreFilter':
                                {'scripts': ['Latin', 'Latin'],
                                 'sthreshold': [1, 1]}},
-                              {'WordAlignFilter': {'tokenizer': 'none',
-                                                   'priors': 'RF1_align.priors',
+                              {'WordAlignFilter': {'priors': 'RF1_align.priors',
                                                    'model': 3,
                                                    'src_threshold': 0,
                                                    'tgt_threshold': 0}},

--- a/tests/test_opusfilter.py
+++ b/tests/test_opusfilter.py
@@ -1,4 +1,3 @@
-import argparse
 import copy
 import json
 import logging
@@ -7,13 +6,14 @@ import requests
 import shutil
 import tempfile
 import unittest
+from argparse import Namespace
 from unittest import mock
 
 from opustools import OpusGet
 
 from opusfilter import ConfigurationError
-from opusfilter.opusfilter import OpusFilter
-from opusfilter.util import Var, VarStr
+from opusfilter.opusfilter import OpusFilter, ParallelWrapper
+from opusfilter.util import Var, VarStr, count_lines, file_open
 
 try:
     import varikn
@@ -1125,3 +1125,185 @@ class TestVariables(unittest.TestCase):
         for case in [Var('unk'), VarStr('{}'), VarStr('{unk}'), VarStr('{mystr}-{unk}')]:
             with self.assertRaises(ConfigurationError):
                 self.of._expand_parameters(case, variables)
+
+
+@unittest.skipIf('varikn' not in globals() or os.environ.get('EFLOMAL_PATH') is None, 'varikn or eflomal not found')
+class TestParallel(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        self.tempdir = tempfile.mkdtemp()
+        self.configuration = {
+            'common': {'output_directory': self.tempdir},
+            'steps':
+            [{'type': 'opus_read',
+              'parameters': {'corpus_name': 'RF',
+                             'source_language': 'en',
+                             'target_language': 'sv',
+                             'release': 'latest',
+                             'preprocessing': 'xml',
+                             'src_output': 'RF1_sents.en',
+                             'tgt_output': 'RF1_sents.sv'}},
+             {'type': 'preprocess',
+              'parameters': {
+                    'inputs': ['RF1_sents.en', 'RF1_sents.sv'],
+                    'outputs': ['RF1_preprocessed.en', 'RF1_preprocessed.sv'],
+                    'n_jobs': 5,
+                    'preprocessors': [{'Tokenizer':
+                                      {'languages': ['en', 'sv'],
+                                       'tokenizer': 'moses'}}]}},
+             {'type': 'filter',
+              'parameters': {
+                  'inputs': ['RF1_preprocessed.en', 'RF1_preprocessed.sv'],
+                  'outputs': ['RF1_filtered.en', 'RF1_filtered.sv'],
+                  'n_jobs': 5,
+                  'filters': [{'LanguageIDFilter':
+                               {'languages': ['en', 'sv'],
+                                'thresholds': [0, 0]}},
+                              {'TerminalPunctuationFilter':
+                               {'threshold': -2}},
+                              {'NonZeroNumeralsFilter': {'threshold': 0.5}},
+                              {'CharacterScoreFilter':
+                               {'scripts': ['Latin', 'Latin'],
+                                'thresholds': [1, 1]}}]}},
+             {'type': 'train_ngram',
+              'parameters': {'data': 'RF1_filtered.en',
+                             'parameters': {'norder': 20, 'dscale': 0.001},
+                             'model': 'RF1_en.arpa'}},
+             {'type': 'train_ngram',
+              'parameters': {'data': 'RF1_filtered.sv',
+                             'parameters': {'norder': 20, 'dscale': 0.001},
+                             'model': 'RF1_sv.arpa'}},
+             {'type': 'train_alignment',
+              'parameters': {'src_data': 'RF1_filtered.en',
+                             'tgt_data': 'RF1_filtered.sv',
+                             'parameters': {'src_tokenizer': None, 'tgt_tokenizer': None, 'model': 3},
+                             'output': 'RF1_align.priors'}},
+             {'type': 'score',
+              'parameters': {
+                  'inputs': ['RF1_sents.en', 'RF1_sents.sv'],
+                  'output': 'RF1_scores.en-sv.jsonl',
+                  'n_jobs': 5,
+                  'filters': [{'LanguageIDFilter':
+                               {'languages': ['en', 'sv'],
+                                'thresholds': [0, 0]}},
+                              {'TerminalPunctuationFilter':
+                               {'threshold': -2}},
+                              {'NonZeroNumeralsFilter': {'threshold': 0.5}},
+                              {'CharacterScoreFilter':
+                               {'scripts': ['Latin', 'Latin'],
+                                'sthreshold': [1, 1]}},
+                              {'WordAlignFilter': {'tokenizer': 'none',
+                                                   'priors': 'RF1_align.priors',
+                                                   'model': 3,
+                                                   'src_threshold': 0,
+                                                   'tgt_threshold': 0}},
+                              {'CrossEntropyFilter':
+                               {'lm_params': [{'filename': 'RF1_en.arpa'},
+                                              {'filename': 'RF1_sv.arpa'}],
+                                'thresholds': [50.0, 50.0],
+                                'diff_threshold': 10.0}}]}},
+             ]}
+        OpusGet(directory='RF', source='en', target='sv', release='latest',
+                preprocess='xml', suppress_prompts=True, download_dir=self.tempdir
+                ).get_files()
+        self.opus_filter = OpusFilter(self.configuration)
+        self.opus_filter.execute_steps()
+
+    def test_parallel_preprocess(self):
+        assert os.path.exists(os.path.join(self.tempdir, 'RF1_preprocessed.en'))
+        assert os.path.exists(os.path.join(self.tempdir, 'RF1_preprocessed.sv'))
+        assert count_lines(os.path.join(self.tempdir, 'RF1_preprocessed.en')) == \
+            count_lines(os.path.join(self.tempdir, 'RF1_sents.en'))
+        assert count_lines(os.path.join(self.tempdir, 'RF1_preprocessed.sv')) == \
+            count_lines(os.path.join(self.tempdir, 'RF1_sents.sv'))
+
+    def test_parallel_filter(self):
+        assert os.path.exists(os.path.join(self.tempdir, 'RF1_filtered.en'))
+        assert os.path.exists(os.path.join(self.tempdir, 'RF1_filtered.sv'))
+        assert count_lines(os.path.join(self.tempdir, 'RF1_filtered.en')) < \
+            count_lines(os.path.join(self.tempdir, 'RF1_preprocessed.en'))
+        assert count_lines(os.path.join(self.tempdir, 'RF1_filtered.sv')) < \
+            count_lines(os.path.join(self.tempdir, 'RF1_preprocessed.sv'))
+
+    def test_parallel_score(self):
+        assert os.path.exists(os.path.join(self.tempdir, 'RF1_scores.en-sv.jsonl'))
+        assert count_lines(os.path.join(self.tempdir, 'RF1_scores.en-sv.jsonl')) == \
+            count_lines(os.path.join(self.tempdir, 'RF1_sents.en'))
+
+
+class TestParallelWrapper(unittest.TestCase):
+    def setUp(self):
+        self.parameters = [
+            {"num_lines": 1, "n_jobs": 5, 'limit': None, 'format': None},  # Test edge condition， n_jobs greater than num_lines
+            {"num_lines": 100, "n_jobs": 1, 'limit': None, 'format': None},
+            {"num_lines": 200, "n_jobs": 9, 'limit': None, 'format': None},
+            {"num_lines": 200, "n_jobs": 10, 'limit': None, 'format': ".gz"},  # Test gzip format inputs and outputs
+            {"num_lines": 50, "n_jobs": 10, 'limit': 20, 'format': None},
+        ]
+
+    def test_split_merge(self):
+        for param in self.parameters:
+            format = param.get('format', None)
+            inputs = [tempfile.mkstemp(suffix=format)[1], tempfile.mkstemp(suffix=format)[1]]
+            outputs = [tempfile.mkstemp(suffix=format)[1], tempfile.mkstemp(suffix=format)[1]]
+
+            for input_ in inputs:
+                fin = file_open(input_, 'w')
+                for i in range(param["num_lines"]):
+                    fin.write("{}\n".format(i))
+                fin.close()
+
+            in_chunked_files, out_chunked_files = ParallelWrapper.split(inputs, outputs, param["n_jobs"])
+            assert len(in_chunked_files) == min(param["n_jobs"], param["num_lines"])
+            assert len(out_chunked_files) == min(param["n_jobs"], param["num_lines"])
+            for files in in_chunked_files:
+                num_lines = [count_lines(f) for f in files]
+                assert all(n == num_lines[0] for n in num_lines)
+            # just copy the files
+            for in_files, out_files in zip(in_chunked_files, out_chunked_files):
+                for fin, fout in zip(in_files, out_files):
+                    shutil.copyfile(fin, fout)
+            ParallelWrapper.merge(in_chunked_files, outputs, out_chunked_files, param.get("limit", None))
+            for output in outputs:
+                if param.get("limit", None) is not None:
+                    assert count_lines(output) == param["limit"]
+                else:
+                    assert count_lines(output) == param["num_lines"]
+
+    def test_parallelize(self):
+        mock_obj = Namespace()
+        mock_obj.output_dir = tempfile.mkdtemp()
+        mock_obj.default_n_jobs = 1
+        mock_obj._check_extra_parameters = OpusFilter._check_extra_parameters
+
+        @ParallelWrapper({'inputs', 'outputs', 'limit'})
+        def func(self, parameters, overwrite=False):
+            inputs = parameters['inputs']
+            outputs = parameters['outputs']
+            for input_, output in zip(inputs, outputs):
+                input_ = os.path.join(self.output_dir, input_)
+                output = os.path.join(self.output_dir, output)
+                shutil.copyfile(input_, output)
+
+        for param in self.parameters:
+            format = param.get('format', None)
+            inputs = [tempfile.mkstemp(dir=mock_obj.output_dir, suffix=format)[1],
+                      tempfile.mkstemp(dir=mock_obj.output_dir, suffix=format)[1]]
+            rel_inputs = [os.path.basename(path) for path in inputs]
+            outputs = [tempfile.mkstemp(dir=mock_obj.output_dir, suffix=format)[1],
+                       tempfile.mkstemp(dir=mock_obj.output_dir, suffix=format)[1]]
+            rel_outputs = [os.path.basename(path) for path in outputs]
+
+            for input_ in inputs:
+                fin = file_open(input_, 'w')
+                for i in range(param["num_lines"]):
+                    fin.write("{}\n".format(i))
+                fin.close()
+            n_jobs = param["n_jobs"]
+            func(mock_obj, {'inputs': rel_inputs, 'outputs': rel_outputs, "n_jobs": n_jobs,
+                            "limit": param.get('limit', None)}, overwrite=True)
+            for output in outputs:
+                if param.get("limit", None) is not None:
+                    assert count_lines(output) == param["limit"]
+                else:
+                    assert count_lines(output) == param["num_lines"]


### PR DESCRIPTION
Related to #28. A draft implementation. If this idea is ok, I will add some test cases.
I try to add a parameter `n_jobs` to parallel functions preprocess, score, and filter.
An example config like this
```yaml
common:
  output_directory: .

steps:
  - type: remove_duplicates
    parameters:
      inputs: [de, en]
      outputs: [de.dedump ,en.dedump]

  - type: filter
    parameters:
      inputs: [de.dedump, en.dedump]
      outputs: [de.rules, en.rules]
      filterfalse: false
      n_jobs: 20
      filters:
        - LengthFilter:
            unit: [word, word]
            min_length: 1
            max_length: 250
        - LengthRatioFilter:
            unit: word
            threshold: 3
        - LongWordFilter:
            threshold: 40
        - LanguageIDFilter:
            languages: [de, en]
            id_method: fasttext
            thresholds: [0.5]
            fasttext_model_path: lid.176.bin
```