### PR TITLE
Improve handling whitespace in Jieba and MeCab tokenization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1493,23 +1493,36 @@ Parameters:
 
 * `tokenizer`: tokenizer type or a list of types for each input
 * `languages`: a list of language codes for each input
-* `options`: tokenizer options dictionary or a list of tokenizer dictionaries for multiple tokenziers (optional)
+* `options`: tokenizer options dictionary, or a list of tokenizer
+  dictionaries for multiple tokenziers (optional)
 
 Supported tokenizers:
 
 * `moses`:
   * Uses the [fast-mosestokenizer](https://github.com/mingruimingrui/fast-mosestokenizer) package.
   * Avaliable for most languages.
-  * Options are passed to the `mosestokenizer.MosesTokenizer` class; see its documentation for the available options.
+  * Options are passed to the `mosestokenizer.MosesTokenizer` class;
+    see its documentation for the available options.
 * `jieba`:
   * Uses the [jieba](https://github.com/fxsjy/jieba) package.
   * Only avaliable for Chinese (zh, zh_CN).
-  * Options are passed to `jieba.cut` function; see its documentation for the avaliable options.
+  * In order to keep track of original space characters, they are by
+    default converted to "␣" before tokenization. The character can be
+    changed with the `map_space_to` option, or the feature disabled by
+    giving `null` or an empty string as the value.
+  * Other options are passed to `jieba.cut` function; see its
+    documentation for the avaliable options.
   * If you use `jieba`, please install OpusFilter with extras `[jieba]` or `[all]`.
 * `mecab`:
   * Uses the [MeCab](https://github.com/SamuraiT/mecab-python3) package.
   * Only avaliable for Japanese (jp).
-  * By default, `unidic-lite` dictionary is installed and used. Other dictionaries can be used by providing appropriate option string in the `mecab_args` option.
+  * In order to keep track of original space characters, they are by
+    default converted to "␣" before tokenization. The character can be
+    changed with the `map_space_to` option, or the feature disabled by
+    giving `null` or an empty string as the value.
+  * By default, `unidic-lite` dictionary is installed and used. Other
+    dictionaries can be used by providing appropriate option string in
+    the `mecab_args` option.
   * If you use `mecab`, please install OpusFilter with extras `[mecab]` or `[all]`.
 
 The list of language codes should match to the languages of the input

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `map_space_to` option for Jieba and MeCab tokenizers to preserve
+  existing space characters in input
+
 ### Fixed
 
 - catch TypeError exceptions from BeautifulSoup in HtmlTagFilter

--- a/opusfilter/tokenization.py
+++ b/opusfilter/tokenization.py
@@ -91,7 +91,7 @@ class MosesTokenizer(DummyTokenizer):
 class JiebaTokenizer(DummyTokenizer):
     """Wrapper for popular Chinese tokenizer jieba"""
 
-    def __init__(self, lang, **options):
+    def __init__(self, lang, map_space_to='␣', **options):
         if not lang.startswith('zh'):
             logger.warning("Jieba tokenizer only avaliable for Chinese (zh), requested language %s", lang)
         try:
@@ -99,20 +99,25 @@ class JiebaTokenizer(DummyTokenizer):
         except NameError as err:
             logger.error("Install jieba to support jieba tokenization")
             raise err
+        self.map_space_to = map_space_to
         self.options = options
 
     def tokenize(self, string):
+        if self.map_space_to:
+            string = string.replace(' ', self.map_space_to)
         return ' '.join(self.jieba.cut(string, **self.options))
 
     def detokenize(self, string):
-        segments = ["".join(item.split(" ")) for item in string.split("   ")]
-        return " ".join(segments)
+        output = ''.join(string.split())
+        if self.map_space_to:
+            output = output.replace(self.map_space_to, ' ')
+        return output
 
 
 class MeCabTokenizer(DummyTokenizer):
     """Wrapper for Japanese tokenization with MeCab"""
 
-    def __init__(self, lang, mecab_args=''):
+    def __init__(self, lang, map_space_to='␣', mecab_args=''):
         if not lang.startswith('jp'):
             logger.warning("MeCab tokenizer is for Japanese (jp), requested language %s", lang)
         try:
@@ -123,12 +128,18 @@ class MeCabTokenizer(DummyTokenizer):
         except RuntimeError as err:
             logger.error("Install unidic-lite or other dictionary to support MeCab tokenization")
             raise err
+        self.map_space_to = map_space_to
 
     def tokenize(self, string):
+        if self.map_space_to:
+            string = string.replace(' ', self.map_space_to)
         return self.tagger.parse(string).strip()
 
     def detokenize(self, string):
-        return ''.join(string.split())
+        output = ''.join(string.split())
+        if self.map_space_to:
+            output = output.replace(self.map_space_to, ' ')
+        return output
 
 
 def get_tokenize(specs):

--- a/opusfilter/tokenization.py
+++ b/opusfilter/tokenization.py
@@ -1,7 +1,6 @@
 """Tokenization tools"""
 
 import logging
-import re
 
 from . import ConfigurationError
 

--- a/opusfilter/tokenization.py
+++ b/opusfilter/tokenization.py
@@ -1,6 +1,7 @@
 """Tokenization tools"""
 
 import logging
+import re
 
 from . import ConfigurationError
 
@@ -105,7 +106,8 @@ class JiebaTokenizer(DummyTokenizer):
         return ' '.join(self.jieba.cut(string, **self.options))
 
     def detokenize(self, string):
-        return ''.join(string.split())
+        segments = ["".join(item.split(" ")) for item in string.split("   ")]
+        return " ".join(segments)
 
 
 class MeCabTokenizer(DummyTokenizer):

--- a/tests/test_tokenization.py
+++ b/tests/test_tokenization.py
@@ -59,10 +59,16 @@ class TestTokenization(unittest.TestCase):
 
     @unittest.skipIf('jieba' not in globals(), 'jieba not installed')
     def test_jieba_detok(self):
-        tokenize = tokenization.get_tokenize(('jieba', 'zh'))
-        tokens = "同时 ， 祖马 革命 的 一代 似乎 对 领导 打破 种族隔离 制度 15 年 后 的 南非 （ South   Africa ) ， 还 不 适应 。"
+        tokenize = tokenization.get_tokenize(('jieba', 'zh', {'map_space_to': '␣'}))
+        tokens = "同时 ， 祖马 革命 的 一代 似乎 对 领导 打破 种族隔离 制度 15 年 后 的 南非 （ South ␣ Africa ) ， 还 不 适应 。"
         reference = "同时，祖马革命的一代似乎对领导打破种族隔离制度15年后的南非（South Africa)，还不适应。"
         self.assertEqual(tokenize.detokenize(tokens), reference)
+
+    @unittest.skipIf('jieba' not in globals(), 'jieba not installed')
+    def test_jieba_tok_and_detok(self):
+        tokenize = tokenization.get_tokenize(('jieba', 'zh', {'map_space_to': '␣'}))
+        text = " 年后的南非（South Africa)，还不适应。 "
+        self.assertEqual(tokenize.detokenize(tokenize(text)), text)
 
     @unittest.skipIf('jieba' not in globals(), 'jieba not installed')
     def test_jieba_non_zh(self):
@@ -75,6 +81,19 @@ class TestTokenization(unittest.TestCase):
         tokenize = tokenization.get_tokenize(('mecab', 'jp'))
         text = "これは英語で書く必要はありません。"
         self.assertEqual(tokenize(text), "これ は 英語 で 書く 必要 は あり ませ ん 。")
+
+    @unittest.skipIf('MeCab' not in globals(), 'MeCab not installed')
+    def test_mecab_detok(self):
+        tokenize = tokenization.get_tokenize(('mecab', 'jp', {'map_space_to': '␣'}))
+        tokens = "これ は 英語 ␣ ( not ␣ here ) ␣ で 書く 必要 は あり ませ ん 。"
+        reference = "これは英語 (not here) で書く必要はありません。"
+        self.assertEqual(tokenize.detokenize(tokens), reference)
+
+    @unittest.skipIf('MeCab' not in globals(), 'MeCab not installed')
+    def test_mecab_tok_and_detok(self):
+        tokenize = tokenization.get_tokenize(('mecab', 'jp', {'map_space_to': '␣'}))
+        text = " これは英語 (not here) で書く必要はありません。 "
+        self.assertEqual(tokenize.detokenize(tokenize(text)), text)
 
     @unittest.skipIf('MeCab' not in globals(), 'MeCab not installed')
     def test_mecab_non_jp(self):

--- a/tests/test_tokenization.py
+++ b/tests/test_tokenization.py
@@ -60,8 +60,8 @@ class TestTokenization(unittest.TestCase):
     @unittest.skipIf('jieba' not in globals(), 'jieba not installed')
     def test_jieba_detok(self):
         tokenize = tokenization.get_tokenize(('jieba', 'zh'))
-        tokens = "同时 ， 祖马 革命 的 一代 似乎 对 领导 打破 种族隔离 制度 15 年 后 的 南非 ， 还 不 适应 。"
-        reference = "同时，祖马革命的一代似乎对领导打破种族隔离制度15年后的南非，还不适应。"
+        tokens = "同时 ， 祖马 革命 的 一代 似乎 对 领导 打破 种族隔离 制度 15 年 后 的 南非 （ South   Africa ) ， 还 不 适应 。"
+        reference = "同时，祖马革命的一代似乎对领导打破种族隔离制度15年后的南非（South Africa)，还不适应。"
         self.assertEqual(tokenize.detokenize(tokens), reference)
 
     @unittest.skipIf('jieba' not in globals(), 'jieba not installed')


### PR DESCRIPTION
Add new option to map original space characters before tokenization (and back after detokenization) in order to keep track of them.