### PR TITLE
Add letter_words_only option for duplicate removal

### DIFF
--- a/bin/opusfilter-duplicates
+++ b/bin/opusfilter-duplicates
@@ -3,6 +3,7 @@
 import argparse
 import collections
 import logging
+import json
 
 from tqdm import tqdm
 
@@ -24,20 +25,29 @@ parser.add_argument('--hash', type=str, default='xxh64',
                     help=('hash function from xxhash library, empty string '
                           'for no hashing (default "xxh64")'))
 parser.add_argument('--letters-only', action='store_true', default=False,
-                    help='lowercase input strings before hashing')
-parser.add_argument('--lowercase', action='store_true', default=False,
                     help='remove all non-letters from intput strings before hashing')
+parser.add_argument('--letters-words-only', action='store_true', default=False,
+                    help='remove words with non-letter characters before hashing')
+parser.add_argument('--lowercase', action='store_true', default=False,
+                    help='lowercase input strings before hashing')
+parser.add_argument('--tokenizers', type=str, metavar='JSON', default=None,
+                    help=('load tokenizer specifications from a JSON list (e.g. \'[["moses", "en"], ["jieba", "zh"]]\'); '
+                          'use with --letters-words-only'))
 
 args = parser.parse_args()
 
 if args.overlap and len(args.overlap) != len(args.files):
     raise ValueError("The number of the main and overlap input files should match")
 
+tokenizers = json.loads(args.tokenizers) if args.tokenizers else None
+
 hasher = SegmentHasher(
     compare='all',
     method=args.hash,
     letters_only=args.letters_only,
-    lowercase=args.lowercase
+    letter_words_only=args.letter_words_only,
+    lowercase=args.lowercase,
+    tokenizers=tokenizers
 )
 
 total = 0

--- a/bin/opusfilter-duplicates
+++ b/bin/opusfilter-duplicates
@@ -32,7 +32,7 @@ parser.add_argument('--lowercase', action='store_true', default=False,
                     help='lowercase input strings before hashing')
 parser.add_argument('--tokenizers', type=str, metavar='JSON', default=None,
                     help=('load tokenizer specifications from a JSON list (e.g. \'[["moses", "en"], ["jieba", "zh"]]\'); '
-                          'use with --letters-words-only'))
+                          'use with --letter-words-only'))
 
 args = parser.parse_args()
 

--- a/bin/opusfilter-duplicates
+++ b/bin/opusfilter-duplicates
@@ -26,7 +26,7 @@ parser.add_argument('--hash', type=str, default='xxh64',
                           'for no hashing (default "xxh64")'))
 parser.add_argument('--letters-only', action='store_true', default=False,
                     help='remove all non-letters from intput strings before hashing')
-parser.add_argument('--letters-words-only', action='store_true', default=False,
+parser.add_argument('--letter-words-only', action='store_true', default=False,
                     help='remove words with non-letter characters before hashing')
 parser.add_argument('--lowercase', action='store_true', default=False,
                     help='lowercase input strings before hashing')

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - support for selection of possible languages for `lingua` language detection
+- `letter_words_only` option for duplicate detection
 
 ### Fixed
 

--- a/docs/command_line_tools.md
+++ b/docs/command_line_tools.md
@@ -31,7 +31,7 @@ between them. The syntax for the `opusfilter-duplicates` is:
 
 ```
 opusfilter-duplicates [--overlap FILE [FILE ...]] [--hash HASH] [--letters-only]
-[--letters-words-only] [--lowercase] [--tokenizers JSON] FILE [FILE ...]
+[--letter-words-only] [--lowercase] [--tokenizers JSON] FILE [FILE ...]
 ```
 
 The options are essentially the same as for [`remove_duplicates`](remove_duplicates).

--- a/docs/command_line_tools.md
+++ b/docs/command_line_tools.md
@@ -30,7 +30,8 @@ number of duplicates in it, or two corpora for calculating the overlap
 between them. The syntax for the `opusfilter-duplicates` is:
 
 ```
-opusfilter-duplicates [--overlap FILE [FILE ...]] [--hash HASH] [--letters-only] [--lowercase] FILE [FILE ...]
+opusfilter-duplicates [--overlap FILE [FILE ...]] [--hash HASH] [--letters-only]
+[--letters-words-only] [--lowercase] [--tokenizers JSON] FILE [FILE ...]
 ```
 
 The options are essentially the same as for [`remove_duplicates`](remove_duplicates).

--- a/docs/functions/filtering_and_scoring.md
+++ b/docs/functions/filtering_and_scoring.md
@@ -14,7 +14,7 @@ Parameters:
 * `letters_only`: remove all non-letters from intput strings before hashing (optional; default `false`)
 * `letter_words_only`: remove words with non-letter characters before hashing (optional; default `false`)
 * `lowercase`: lowercase input strings before hashing (optional; default `false`)
-* `tokenizers`: load tokenizer specifications from a list (optional; use with `letters_words_only`)
+* `tokenizers`: load tokenizer specifications from a list (optional; use with `letter_words_only`)
 
 Duplicate filtering is recommended as a first step especially if you
 combine different corpus collections (e.g. data crawled from web) and

--- a/docs/functions/filtering_and_scoring.md
+++ b/docs/functions/filtering_and_scoring.md
@@ -11,6 +11,10 @@ Parameters:
 * `compare`: select files for duplicate comparison (optional; default `all` or a list of indices)
 * `hash`: select hash algorithm from xxhash (optional; default `xxh64`)
 * `overlap`: remove overlap with a second set of files (optional; default `null`)
+* `letters_only`: remove all non-letters from intput strings before hashing (optional; default `false`)
+* `letter_words_only`: remove words with non-letter characters before hashing (optional; default `false`)
+* `lowercase`: lowercase input strings before hashing (optional; default `false`)
+* `tokenizers`: load tokenizer specifications from a list (optional; use with `letters_words_only`)
 
 Duplicate filtering is recommended as a first step especially if you
 combine different corpus collections (e.g. data crawled from web) and
@@ -37,6 +41,10 @@ default 64-bit XXHash algorithm should be fine for any practical data
 sizes, but if do not care about memory use and want to be extra sure
 there are no collisions, you can disable hashing by setting the `hash`
 parameter as empty string or null.
+
+For the `letter_words_only`, unless the input is pre-tokenized, you
+should select tokenizers for each of the input files. See
+[Tokenizer](tokenizer.md) for description of the tokenizer parameters.
 
 ## filter
 

--- a/opusfilter/opusfilter.py
+++ b/opusfilter/opusfilter.py
@@ -901,7 +901,8 @@ class OpusFilter:
     def remove_duplicates(self, parameters, overwrite=False):
         """Remove duplicates from parallel lines in files"""
         self._check_extra_parameters(
-            {'inputs', 'outputs', 'compare', 'hash', 'letters_only', 'lowercase', 'overlap'}, parameters)
+            {'inputs', 'outputs', 'compare', 'hash', 'letters_only', 'letter_words_only',
+             'lowercase', 'tokenizers', 'overlap'}, parameters)
         outfiles = [os.path.join(self.output_dir, fname) for fname in parameters['outputs']]
         infiles = [os.path.join(self.output_dir, fname) for fname in parameters['inputs']]
         if len(outfiles) != len(infiles):
@@ -914,7 +915,9 @@ class OpusFilter:
             compare=parameters.get('compare', 'all'),
             method=parameters.get('hash', 'xxh64'),
             letters_only=parameters.get('letters_only', False),
+            letter_words_only=parameters.get('letter_words_only', False),
             lowercase=parameters.get('lowercase', False),
+            tokenizers=parameters.get('tokenizers')
         )
         infs = [file_open(infile) for infile in infiles]
         outfs = [file_open(outfile, 'w') for outfile in outfiles]

--- a/opusfilter/segment_hash.py
+++ b/opusfilter/segment_hash.py
@@ -74,7 +74,6 @@ class SegmentHasher:
             if tokenizer:
                 inputstr = tokenizer.tokenize(inputstr)
             inputstr = ' '.join(token for token in inputstr.split() if self.letters.search(token))
-            logging.error(inputstr)
         if self.letters_only:
             inputstr = regex.sub(self.not_letter, '', inputstr)
         if self.lowercase:

--- a/tests/test_segment_hash.py
+++ b/tests/test_segment_hash.py
@@ -35,6 +35,24 @@ class TestFilterPipeline(unittest.TestCase):
             logging.debug("Testing non-letter %s", example)
             self.assertEqual(hasher.preprocess(example), '')
 
+    def test_letter_words_only_preprocess(self):
+        """Test preprocessing options"""
+        inputs = ["This is a test case <n> .", "There are 42 cases left , if you trust t84at"]
+        expected_outputs = ["This is a test case", "There are cases left if you trust"]
+        hasher = SegmentHasher(letter_words_only=True)
+        for input_, expected in zip(inputs, expected_outputs):
+            output = hasher.preprocess(input_)
+            self.assertEqual(output, expected)
+
+    def test_letter_words_only_with_tokenization(self):
+        """Test preprocessing options"""
+        segs1 = ["This is a test case <4>.", "There are 42 cases left, if you trust t84at"]
+        segs2 = ["this is a test case <5>!", "there are 12 cases left - if you trust m3"]
+        hasher = SegmentHasher(letter_words_only=True, lowercase=True, tokenizers=[('moses', 'en')])
+        for seg1, seg2 in zip(segs1, segs2):
+            out1, out2 = hasher.apply([seg1]), hasher.apply([seg2])
+            self.assertEqual(out1, out2)
+
     def _test_multiple(self, hasher, segment, variants, results):
         for variant, result in zip(variants, results):
             match = (hasher.apply(segment) == hasher.apply(variant))


### PR DESCRIPTION
This should help removing near-duplicate sentences that have a varying non-word token (e.g. number, product ID).